### PR TITLE
feat: redirect authenticated users from homepage to dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,14 @@
 import Image from "next/image";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth();
+
+  if (userId) {
+    redirect("/dashboard");
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">


### PR DESCRIPTION
Added authentication check on the homepage to redirect logged-in users to the dashboard. This provides a better user experience by taking authenticated users directly to their dashboard instead of showing the landing page.

Changes:
- Import auth() from @clerk/nextjs/server
- Import redirect() from next/navigation
- Check userId from auth() and redirect to /dashboard if user is logged in
- Follows Server Component patterns and auth standards from docs

Closes #3